### PR TITLE
Add draft cloud sync + history

### DIFF
--- a/api/draft/function.json
+++ b/api/draft/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get", "put", "post", "delete", "options"],
+      "route": "draft/{action?}/{id?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/api/draft/index.js
+++ b/api/draft/index.js
@@ -1,0 +1,220 @@
+const { TableClient } = require('@azure/data-tables');
+
+const TABLE_NAME = 'drafts';
+const SCHEMA_VERSION = 1;
+const MAX_STATE_BYTES = 64 * 1024;
+const REVERSE_TS_BASE = 9999999999999;
+
+let _tableClientPromise = null;
+function getTableClient() {
+    if (_tableClientPromise) return _tableClientPromise;
+    const conn = process.env.DRAFTS_STORAGE_CONNECTION_STRING;
+    if (!conn) return Promise.reject(new Error('Storage connection string not configured.'));
+    const client = TableClient.fromConnectionString(conn, TABLE_NAME, { allowInsecureConnection: false });
+    _tableClientPromise = client.createTable().catch(() => {}).then(() => client);
+    return _tableClientPromise;
+}
+
+function getPrincipal(req) {
+    const header = req.headers && req.headers['x-ms-client-principal'];
+    if (!header) return null;
+    try {
+        const decoded = Buffer.from(header, 'base64').toString('utf8');
+        const p = JSON.parse(decoded);
+        if (!p || !p.userId) return null;
+        if (!Array.isArray(p.userRoles) || !p.userRoles.includes('authenticated')) return null;
+        return p;
+    } catch (e) {
+        return null;
+    }
+}
+
+function corsHeaders() {
+    return {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, PUT, POST, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+    };
+}
+
+function respond(context, status, body) {
+    context.res = {
+        status,
+        headers: corsHeaders(),
+        body: body == null ? '' : JSON.stringify(body),
+    };
+}
+
+function partitionKey(userId) {
+    return 'u_' + userId;
+}
+
+function reverseTs(ts) {
+    const v = (REVERSE_TS_BASE - ts).toString();
+    return v.padStart(13, '0');
+}
+
+function shortId() {
+    const alphabet = '0123456789abcdefghjkmnpqrstvwxyz';
+    let out = '';
+    for (let i = 0; i < 6; i++) out += alphabet[Math.floor(Math.random() * alphabet.length)];
+    return out;
+}
+
+function isValidStateBlob(s) {
+    if (typeof s !== 'string') return false;
+    if (Buffer.byteLength(s, 'utf8') > MAX_STATE_BYTES) return false;
+    return true;
+}
+
+async function loadActive(table, pk) {
+    try {
+        const entity = await table.getEntity(pk, 'active');
+        return entity;
+    } catch (e) {
+        if (e && e.statusCode === 404) return null;
+        throw e;
+    }
+}
+
+async function getHistoryEntry(table, pk, id) {
+    try {
+        return await table.getEntity(pk, id);
+    } catch (e) {
+        if (e && e.statusCode === 404) return null;
+        throw e;
+    }
+}
+
+async function listHistoryEntries(table, pk) {
+    // RowKey range covers all 'hist_*' rows. Upper bound 'hist`' uses backtick (0x60),
+    // which sorts immediately after underscore (0x5F).
+    const filterStr = `PartitionKey eq '${pk}' and RowKey ge 'hist_' and RowKey lt 'hist\`'`;
+    const entries = [];
+    const iter = table.listEntities({ queryOptions: { filter: filterStr } });
+    for await (const ent of iter) {
+        entries.push(ent);
+    }
+    entries.sort((a, b) => (a.rowKey < b.rowKey ? -1 : a.rowKey > b.rowKey ? 1 : 0));
+    return entries;
+}
+
+module.exports = async function (context, req) {
+    if (req.method === 'OPTIONS') {
+        return respond(context, 204, null);
+    }
+
+    const principal = getPrincipal(req);
+    if (!principal) {
+        return respond(context, 401, { error: 'Authentication required.' });
+    }
+
+    const action = (req.params && req.params.action) || '';
+    const id = (req.params && req.params.id) || '';
+    const method = (req.method || 'GET').toUpperCase();
+    const pk = partitionKey(principal.userId);
+
+    let table;
+    try {
+        table = await getTableClient();
+    } catch (e) {
+        context.log.error('[draft] storage init failed:', e.message);
+        return respond(context, 500, { error: 'Storage not configured.' });
+    }
+
+    try {
+        if (action === 'active' && method === 'GET') {
+            const entity = await loadActive(table, pk);
+            if (!entity) return respond(context, 404, { error: 'No active draft.' });
+            return respond(context, 200, {
+                state: entity.state ? JSON.parse(entity.state) : null,
+                lastModifiedAt: Number(entity.lastModifiedAt) || 0,
+                clientId: entity.clientId || null,
+                schemaVersion: entity.schemaVersion || SCHEMA_VERSION,
+            });
+        }
+
+        if (action === 'active' && method === 'PUT') {
+            const body = req.body || {};
+            const stateBlob = JSON.stringify(body.state || {});
+            if (!isValidStateBlob(stateBlob)) {
+                return respond(context, 400, { error: 'state too large or invalid.' });
+            }
+            const lastModifiedAt = Number(body.lastModifiedAt) || Date.now();
+            const clientIdValue = typeof body.clientId === 'string' ? body.clientId : '';
+            const schemaVersion = Number(body.schemaVersion) || SCHEMA_VERSION;
+            const entity = {
+                partitionKey: pk,
+                rowKey: 'active',
+                state: stateBlob,
+                lastModifiedAt,
+                clientId: clientIdValue,
+                userDetails: principal.userDetails || '',
+                schemaVersion,
+            };
+            await table.upsertEntity(entity, 'Replace');
+            return respond(context, 200, { ok: true, lastModifiedAt });
+        }
+
+        if (action === 'active' && method === 'DELETE') {
+            try {
+                await table.deleteEntity(pk, 'active');
+            } catch (e) {
+                if (!e || e.statusCode !== 404) throw e;
+            }
+            return respond(context, 200, { ok: true });
+        }
+
+        if (action === 'archive' && method === 'POST') {
+            const body = req.body || {};
+            const stateBlob = JSON.stringify(body.state || {});
+            if (!isValidStateBlob(stateBlob)) {
+                return respond(context, 400, { error: 'state too large or invalid.' });
+            }
+            const summaryMetaBlob = JSON.stringify(body.summaryMeta || {});
+            const archivedAt = Date.now();
+            const rowKey = `hist_${reverseTs(archivedAt)}_${shortId()}`;
+            const schemaVersion = Number(body.schemaVersion) || SCHEMA_VERSION;
+            const entity = {
+                partitionKey: pk,
+                rowKey,
+                state: stateBlob,
+                summaryMeta: summaryMetaBlob,
+                archivedAt,
+                lastModifiedAt: archivedAt,
+                userDetails: principal.userDetails || '',
+                schemaVersion,
+            };
+            await table.createEntity(entity);
+            return respond(context, 200, { ok: true, id: rowKey, archivedAt });
+        }
+
+        if (action === 'history' && method === 'GET' && !id) {
+            const entries = await listHistoryEntries(table, pk);
+            const out = entries.map(e => ({
+                id: e.rowKey,
+                archivedAt: Number(e.archivedAt) || 0,
+                summaryMeta: e.summaryMeta ? JSON.parse(e.summaryMeta) : {},
+            }));
+            return respond(context, 200, { entries: out });
+        }
+
+        if (action === 'history' && method === 'GET' && id) {
+            const entity = await getHistoryEntry(table, pk, id);
+            if (!entity) return respond(context, 404, { error: 'Not found.' });
+            return respond(context, 200, {
+                id: entity.rowKey,
+                archivedAt: Number(entity.archivedAt) || 0,
+                state: entity.state ? JSON.parse(entity.state) : null,
+                summaryMeta: entity.summaryMeta ? JSON.parse(entity.summaryMeta) : {},
+                schemaVersion: entity.schemaVersion || SCHEMA_VERSION,
+            });
+        }
+
+        return respond(context, 404, { error: 'Unknown route.' });
+    } catch (e) {
+        context.log.error('[draft] handler error:', e && e.message, e && e.stack);
+        return respond(context, 500, { error: 'Server error.', detail: e && e.message });
+    }
+};

--- a/api/package.json
+++ b/api/package.json
@@ -5,5 +5,7 @@
   "scripts": {
     "start": "func start"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@azure/data-tables": "^13.3.1"
+  }
 }

--- a/css/draft.css
+++ b/css/draft.css
@@ -1970,3 +1970,78 @@ body {
         max-width: 100px;
     }
 }
+
+/* ─── Auth indicator (header) ─────────────────────────────────────── */
+.auth-indicator {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 12px;
+    font-size: 0.8em;
+    color: #888;
+}
+.auth-indicator .auth-username {
+    font-weight: 600;
+    color: #555;
+}
+.auth-indicator .auth-link {
+    color: #0066cc;
+    text-decoration: none;
+}
+.auth-indicator .auth-link:hover {
+    text-decoration: underline;
+}
+
+/* ─── History modal ─────────────────────────────────────────────────── */
+.history-modal {
+    width: 520px;
+    max-width: 92vw;
+    max-height: 80vh;
+    overflow-y: auto;
+    position: relative;
+}
+.history-entry {
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    padding: 10px 12px;
+    margin-bottom: 8px;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+}
+.history-entry:hover {
+    background: #f7f7f7;
+    border-color: #ccc;
+}
+.history-entry-date {
+    font-weight: 600;
+    color: #333;
+    font-size: 0.95em;
+}
+.history-entry-meta {
+    color: #666;
+    font-size: 0.85em;
+    margin-top: 2px;
+}
+.history-entry-cards {
+    color: #444;
+    font-size: 0.82em;
+    margin-top: 4px;
+    line-height: 1.3;
+}
+.history-entry-cards strong {
+    color: #888;
+    font-weight: 600;
+}
+
+/* ─── History entry viewer (read-only SummaryView container) ──────── */
+.history-viewer-modal {
+    background: white;
+    border-radius: 12px;
+    padding: 24px;
+    width: 900px;
+    max-width: 94vw;
+    max-height: 85vh;
+    overflow-y: auto;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+    position: relative;
+}

--- a/draft.html
+++ b/draft.html
@@ -14,6 +14,7 @@
     <script src="js/draft-stats.js"></script>
     <script src="js/screenshot-ocr.js"></script>
     <script src="js/strategy-advisor.js"></script>
+    <script src="js/draft-sync.js"></script>
 </head>
 <body>
     <div id="root">
@@ -117,7 +118,8 @@ function loadSavedState() {
 
 function saveState(state) {
     try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+        const stamped = { ...state, _lastModifiedAt: Date.now() };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(stamped));
     } catch { /* ignore quota errors */ }
 }
 
@@ -1160,7 +1162,7 @@ function CardDetailPopover({ card, anchorRect, onClose, wheelWatchNote, onWheelW
 }
 
 // ─── SummaryView Component ──────────────────────────────────────────
-function SummaryView({ draftedCards, cardMap, onNewDraft, hands, othersDrafted, onCardClick, playedCards, onTogglePlayed }) {
+function SummaryView({ draftedCards, cardMap, onNewDraft, hands, othersDrafted, onCardClick, playedCards, onTogglePlayed, readOnly }) {
     const [viewMode, setViewMode] = useState('combined'); // 'combined' or 'myhand'
 
     const allDrafted = [];
@@ -1225,13 +1227,15 @@ function SummaryView({ draftedCards, cardMap, onNewDraft, hands, othersDrafted, 
 
     const renderOpponentCard = (card) => (
         <div key={card.name} className={`summary-card-compact clickable others-pick${playedCards.has(card.name) ? ' played' : ''}`} onClick={(e) => onCardClick && onCardClick(card.name, e)}>
-            <input
-                type="checkbox"
-                className="played-checkbox"
-                checked={playedCards.has(card.name)}
-                onChange={() => onTogglePlayed(card.name)}
-                onClick={(e) => e.stopPropagation()}
-            />
+            {!readOnly && (
+                <input
+                    type="checkbox"
+                    className="played-checkbox"
+                    checked={playedCards.has(card.name)}
+                    onChange={() => onTogglePlayed(card.name)}
+                    onClick={(e) => e.stopPropagation()}
+                />
+            )}
             <span className="card-name-inline">
                 {card.isTemporary && <span className="temp-badge" style={{ marginRight: 4 }}>NEW</span>}
                 {card.name}
@@ -1314,10 +1318,94 @@ function SummaryView({ draftedCards, cardMap, onNewDraft, hands, othersDrafted, 
                 </div>
             )}
 
-            <div style={{ textAlign: 'center', marginTop: '24px' }}>
-                <button className="btn btn-primary" onClick={onNewDraft} style={{ background: 'rgba(255,255,255,0.2)', fontSize: '1.1em' }}>
-                    Start New Draft
-                </button>
+            {!readOnly && (
+                <div style={{ textAlign: 'center', marginTop: '24px' }}>
+                    <button className="btn btn-primary" onClick={onNewDraft} style={{ background: 'rgba(255,255,255,0.2)', fontSize: '1.1em' }}>
+                        Start New Draft
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ─── DraftHistoryModal ──────────────────────────────────────────────
+function DraftHistoryModal({ onClose, onSelect }) {
+    const [entries, setEntries] = useState(null);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        draftSync.listHistory()
+            .then(r => setEntries((r && r.entries) || []))
+            .catch(e => setError(e.message));
+    }, []);
+
+    return (
+        <div className="temp-edit-overlay" onClick={onClose}>
+            <div className="temp-edit-modal history-modal" onClick={(e) => e.stopPropagation()}>
+                <button className="popover-close" onClick={onClose}>&times;</button>
+                <div className="temp-edit-title">Past Drafts</div>
+                {error && <div style={{ color: '#c0392b', fontSize: '0.9em' }}>{error}</div>}
+                {!entries && !error && <div style={{ color: '#888' }}>Loading…</div>}
+                {entries && entries.length === 0 && (
+                    <div style={{ color: '#888', fontStyle: 'italic' }}>No completed drafts yet.</div>
+                )}
+                {entries && entries.map(entry => {
+                    const meta = entry.summaryMeta || {};
+                    const occs = (meta.occupationNames || []).join(', ');
+                    const mins = (meta.minorNames || []).join(', ');
+                    return (
+                        <div key={entry.id} className="history-entry" onClick={() => onSelect(entry.id)}>
+                            <div className="history-entry-date">
+                                {new Date(entry.archivedAt).toLocaleString()}
+                            </div>
+                            <div className="history-entry-meta">
+                                {meta.playerCount ? `${meta.playerCount}p` : ''}
+                                {meta.archetypes && meta.archetypes.length > 0 && (
+                                    <span> · {meta.archetypes.join(' / ')}</span>
+                                )}
+                            </div>
+                            {occs && <div className="history-entry-cards"><strong>Occ:</strong> {occs}</div>}
+                            {mins && <div className="history-entry-cards"><strong>Min:</strong> {mins}</div>}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+// ─── HistoryEntryViewer ─────────────────────────────────────────────
+// Fetches a single archived draft and renders SummaryView in read-only mode.
+function HistoryEntryViewer({ id, cardMap, onClose, onCardClick }) {
+    const [entry, setEntry] = useState(null);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        draftSync.getHistoryEntry(id)
+            .then(r => setEntry(r))
+            .catch(e => setError(e.message));
+    }, [id]);
+
+    return (
+        <div className="temp-edit-overlay" onClick={onClose}>
+            <div className="history-viewer-modal" onClick={(e) => e.stopPropagation()}>
+                <button className="popover-close" onClick={onClose}>&times;</button>
+                {error && <div style={{ color: '#c0392b' }}>{error}</div>}
+                {!entry && !error && <div style={{ color: '#888' }}>Loading…</div>}
+                {entry && entry.state && (
+                    <SummaryView
+                        draftedCards={entry.state.draftedCards || {}}
+                        cardMap={cardMap}
+                        onNewDraft={() => {}}
+                        hands={entry.state.hands || {}}
+                        othersDrafted={entry.state.othersDrafted || []}
+                        onCardClick={onCardClick}
+                        playedCards={new Set(entry.state.playedCards || [])}
+                        onTogglePlayed={() => {}}
+                        readOnly={true}
+                    />
+                )}
             </div>
         </div>
     );
@@ -1387,6 +1475,14 @@ function DraftApp() {
     const [playedCards, setPlayedCards] = useState(new Set());
     const autoAdviceTriggeredRef = useRef(false);
 
+    // Cloud sync state
+    const [currentUser, setCurrentUser] = useState(null);
+    const [showHistoryModal, setShowHistoryModal] = useState(false);
+    const [historyViewId, setHistoryViewId] = useState(null);
+    const archivedRef = useRef(false);
+    const cloudSaveTimerRef = useRef(null);
+    const migrationPushedRef = useRef(false);
+
     const handleFarmCellClick = useCallback((index) => {
         setFarmGrid(prev => {
             const next = [...prev];
@@ -1406,12 +1502,14 @@ function DraftApp() {
 
     // Load card data
     useEffect(() => {
-        fetch('data/agricola-cards.json')
-            .then(res => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch('data/agricola-cards.json');
                 if (!res.ok) throw new Error('Failed to load card data');
-                return res.json();
-            })
-            .then(rawData => {
+                const rawData = await res.json();
+                if (cancelled) return;
+
                 // Deduplicate cards by name (keep first/higher-ranked entry)
                 const seen = new Set();
                 const data = rawData.filter(c => {
@@ -1426,8 +1524,37 @@ function DraftApp() {
                     draftStats.init(data);
                 }
 
-                // Restore saved state after cards are loaded
-                const saved = loadSavedState();
+                // Resolve auth state, then reconcile cloud vs localStorage.
+                const localSaved = loadSavedState();
+                const localTs = (localSaved && localSaved.draftStarted) ? (Number(localSaved._lastModifiedAt) || 0) : 0;
+
+                let user = null;
+                try { user = await draftSync.getCurrentUser(); } catch (e) { user = null; }
+                if (cancelled) return;
+                setCurrentUser(user);
+
+                let chosen = localSaved;
+                let needsMigrationPush = false;
+
+                if (user) {
+                    try {
+                        const cloud = await draftSync.loadActiveDraft();
+                        if (cancelled) return;
+                        if (cloud && cloud.state) {
+                            const cloudTs = Number(cloud.lastModifiedAt) || 0;
+                            if (cloudTs > localTs) {
+                                chosen = cloud.state;
+                            }
+                        } else if (localSaved && localSaved.draftStarted) {
+                            // Cloud empty, local has an active draft → one-time push.
+                            needsMigrationPush = true;
+                        }
+                    } catch (e) {
+                        console.warn('[draft-sync] cloud load failed, using localStorage:', e.message);
+                    }
+                }
+
+                const saved = chosen;
                 if (saved && saved.draftStarted) {
                     // Validate card names still exist in the database
                     const validNames = new Set(data.map(c => c.name));
@@ -1487,11 +1614,23 @@ function DraftApp() {
                 }
                 setRestoredFromStorage(true);
                 setLoading(false);
-            })
-            .catch(err => {
+
+                // One-time migration push: local has an active draft, cloud was empty.
+                if (user && needsMigrationPush && saved && saved.draftStarted && !migrationPushedRef.current) {
+                    migrationPushedRef.current = true;
+                    const stripped = { ...saved };
+                    delete stripped._lastModifiedAt;
+                    draftSync.saveActiveDraft(stripped).catch(err => {
+                        console.warn('[draft-sync] migration push failed:', err.message);
+                    });
+                }
+            } catch (err) {
+                if (cancelled) return;
                 setError(err.message);
                 setLoading(false);
-            });
+            }
+        })();
+        return () => { cancelled = true; };
     }, []);
 
     // Save state to localStorage on changes (after initial restore)
@@ -1528,6 +1667,100 @@ function DraftApp() {
             handleGetAdvice();
         }
     }, [draftComplete, strategyAvailable, strategyResult, strategyLoading, strategyError, handleGetAdvice]);
+
+    // Debounced cloud save (alongside the synchronous localStorage save above).
+    // Skips while draft is complete — the archive effect handles completion.
+    useEffect(() => {
+        if (!restoredFromStorage) return;
+        if (!currentUser) return;
+        if (!draftStarted) return;
+        if (draftComplete) return;
+
+        if (cloudSaveTimerRef.current) clearTimeout(cloudSaveTimerRef.current);
+        cloudSaveTimerRef.current = setTimeout(() => {
+            const stateObj = {
+                currentRound,
+                playerCount,
+                draftStarted,
+                currentHandNames,
+                hands,
+                draftedCards,
+                sortKey,
+                markingPhase,
+                markedRemaining: [...markedRemaining],
+                othersDrafted,
+                farmGrid,
+                strategyNotes,
+                wheelWatch,
+                tempCards,
+                playedCards: [...playedCards],
+            };
+            draftSync.saveActiveDraft(stateObj).catch(err => {
+                console.warn('[draft-sync] cloud save failed:', err.message);
+            });
+        }, 1500);
+
+        return () => {
+            if (cloudSaveTimerRef.current) {
+                clearTimeout(cloudSaveTimerRef.current);
+                cloudSaveTimerRef.current = null;
+            }
+        };
+    }, [restoredFromStorage, currentUser, draftStarted, draftComplete, currentRound, playerCount, currentHandNames, hands, draftedCards, sortKey, markingPhase, markedRemaining, othersDrafted, farmGrid, strategyNotes, wheelWatch, tempCards, playedCards]);
+
+    // Archive completed drafts to cloud history, then clear active slot.
+    useEffect(() => {
+        if (!draftComplete) {
+            archivedRef.current = false;
+            return;
+        }
+        if (!currentUser) return;
+        if (archivedRef.current) return;
+        archivedRef.current = true;
+
+        const stateObj = {
+            currentRound,
+            playerCount,
+            draftStarted,
+            currentHandNames,
+            hands,
+            draftedCards,
+            sortKey,
+            markingPhase,
+            markedRemaining: [...markedRemaining],
+            othersDrafted,
+            farmGrid,
+            strategyNotes,
+            wheelWatch,
+            tempCards,
+            playedCards: [...playedCards],
+        };
+
+        const occupationNames = [];
+        const minorNames = [];
+        Object.values(draftedCards || {}).forEach(picks => {
+            if (picks && picks.occupation) occupationNames.push(picks.occupation);
+            if (picks && picks.minor) minorNames.push(picks.minor);
+        });
+        const archetypes = (strategyResult && Array.isArray(strategyResult.archetypes))
+            ? strategyResult.archetypes
+            : [];
+
+        const summaryMeta = {
+            playerCount,
+            archetypes,
+            occupationNames,
+            minorNames,
+            finalRound: 7,
+        };
+
+        draftSync.archiveDraft(stateObj, summaryMeta)
+            .then(() => draftSync.deleteActiveDraft().catch(() => {}))
+            .catch(err => {
+                console.warn('[draft-sync] archive failed:', err.message);
+                archivedRef.current = false;
+            });
+    }, [draftComplete, currentUser]);
 
     // Random icon for title
     const [titleIcon] = useState(() => {
@@ -1693,8 +1926,12 @@ function DraftApp() {
         setWheelWatch({});
         setPlayedCards(new Set());
         autoAdviceTriggeredRef.current = false;
+        archivedRef.current = false;
         setDraftStarted(false);
         clearSavedState();
+        if (currentUser) {
+            draftSync.deleteActiveDraft().catch(() => {});
+        }
     };
 
     // --- Background card submission (fire-and-forget) ---
@@ -2105,9 +2342,22 @@ function DraftApp() {
                         {draftStarted && (
                             <span style={{ fontSize: '0.85em', color: '#888', marginRight: '8px' }}>{playerCount}-Player</span>
                         )}
+                        {currentUser && (
+                            <button className="btn btn-secondary" onClick={() => setShowHistoryModal(true)}>Past Drafts</button>
+                        )}
                         {draftStarted && (
                             <button className="btn btn-danger" onClick={handleResetDraft}>Reset Draft</button>
                         )}
+                        <div className="auth-indicator">
+                            {currentUser ? (
+                                <>
+                                    <span className="auth-username" title={currentUser.userDetails}>{currentUser.userDetails}</span>
+                                    <a href={draftSync.LOGOUT_URL} className="auth-link">Sign out</a>
+                                </>
+                            ) : (
+                                <a href={draftSync.LOGIN_URL} className="auth-link">Sign in</a>
+                            )}
+                        </div>
                     </div>
                 </div>
 
@@ -2458,6 +2708,24 @@ function DraftApp() {
                         )}
                     </div>
                 </div>
+            )}
+
+            {/* Draft History Modal */}
+            {showHistoryModal && (
+                <DraftHistoryModal
+                    onClose={() => setShowHistoryModal(false)}
+                    onSelect={(id) => setHistoryViewId(id)}
+                />
+            )}
+
+            {/* History Entry Viewer */}
+            {historyViewId && (
+                <HistoryEntryViewer
+                    id={historyViewId}
+                    cardMap={cardMap}
+                    onClose={() => setHistoryViewId(null)}
+                    onCardClick={handleMiniCardClick}
+                />
             )}
 
             {/* Edit Temp Card Modal */}

--- a/js/draft-sync.js
+++ b/js/draft-sync.js
@@ -1,0 +1,139 @@
+// Cloud sync module for the draft tool.
+// Auth is handled by Azure Static Web Apps (GitHub OAuth); this module just
+// makes calls to /api/draft/* with credentials and reads /.auth/me.
+// Uses `var` for Babel standalone compatibility (matches strategy-advisor.js).
+
+var draftSync = (function () {
+
+    var DRAFT_API = '/api/draft';
+    var AUTH_ME = '/.auth/me';
+    var SCHEMA_VERSION = 1;
+    var USER_CACHE_TTL_MS = 30 * 1000;
+
+    var LOGIN_URL = '/.auth/login/github?post_login_redirect_uri=/draft.html';
+    var LOGOUT_URL = '/.auth/logout?post_logout_redirect_uri=/draft.html';
+
+    // Per-tab client ID — used so the server can echo back which client wrote a row,
+    // letting us detect "did I just write this?" on a subsequent read.
+    var _clientId = (function () {
+        var alphabet = 'abcdefghjkmnpqrstvwxyz0123456789';
+        var out = '';
+        for (var i = 0; i < 16; i++) out += alphabet[Math.floor(Math.random() * alphabet.length)];
+        return out;
+    })();
+
+    var _userCache = null;
+    var _userCacheAt = 0;
+
+    function _request(path, method, body) {
+        var opts = {
+            method: method,
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+        };
+        if (body !== undefined) opts.body = JSON.stringify(body);
+        return fetch(DRAFT_API + path, opts).then(function (res) {
+            if (res.status === 204) return null;
+            return res.json().catch(function () { return null; }).then(function (data) {
+                if (!res.ok) {
+                    var msg = (data && data.error) || ('Request failed (' + res.status + ').');
+                    var err = new Error(msg);
+                    err.status = res.status;
+                    err.data = data;
+                    throw err;
+                }
+                return data;
+            });
+        });
+    }
+
+    function getCurrentUser(opts) {
+        var force = opts && opts.force;
+        var now = Date.now();
+        if (!force && _userCache !== null && (now - _userCacheAt) < USER_CACHE_TTL_MS) {
+            return Promise.resolve(_userCache);
+        }
+        return fetch(AUTH_ME, { credentials: 'same-origin' })
+            .then(function (res) {
+                if (!res.ok) return { clientPrincipal: null };
+                return res.json();
+            })
+            .then(function (data) {
+                var p = data && data.clientPrincipal;
+                _userCache = p ? {
+                    userId: p.userId,
+                    userDetails: p.userDetails,
+                    identityProvider: p.identityProvider,
+                } : null;
+                _userCacheAt = Date.now();
+                return _userCache;
+            })
+            .catch(function () {
+                _userCache = null;
+                _userCacheAt = Date.now();
+                return null;
+            });
+    }
+
+    function clearUserCache() {
+        _userCache = null;
+        _userCacheAt = 0;
+    }
+
+    function loadActiveDraft() {
+        return _request('/active', 'GET').then(function (data) {
+            return data;
+        }).catch(function (err) {
+            if (err && err.status === 404) return null;
+            throw err;
+        });
+    }
+
+    function saveActiveDraft(state) {
+        var lastModifiedAt = Date.now();
+        return _request('/active', 'PUT', {
+            state: state,
+            lastModifiedAt: lastModifiedAt,
+            clientId: _clientId,
+            schemaVersion: SCHEMA_VERSION,
+        }).then(function (data) {
+            return { lastModifiedAt: (data && data.lastModifiedAt) || lastModifiedAt };
+        });
+    }
+
+    function deleteActiveDraft() {
+        return _request('/active', 'DELETE');
+    }
+
+    function archiveDraft(state, summaryMeta) {
+        return _request('/archive', 'POST', {
+            state: state,
+            summaryMeta: summaryMeta || {},
+            schemaVersion: SCHEMA_VERSION,
+        });
+    }
+
+    function listHistory() {
+        return _request('/history', 'GET');
+    }
+
+    function getHistoryEntry(id) {
+        return _request('/history/' + encodeURIComponent(id), 'GET');
+    }
+
+    return {
+        LOGIN_URL: LOGIN_URL,
+        LOGOUT_URL: LOGOUT_URL,
+        SCHEMA_VERSION: SCHEMA_VERSION,
+        getClientId: function () { return _clientId; },
+        getCurrentUser: getCurrentUser,
+        clearUserCache: clearUserCache,
+        loadActiveDraft: loadActiveDraft,
+        saveActiveDraft: saveActiveDraft,
+        deleteActiveDraft: deleteActiveDraft,
+        archiveDraft: archiveDraft,
+        listHistory: listHistory,
+        getHistoryEntry: getHistoryEntry,
+    };
+
+})();

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,6 +1,25 @@
 {
+  "auth": {
+    "identityProviders": {
+      "gitHub": {
+        "registration": {
+          "clientIdSettingName": "GITHUB_CLIENT_ID",
+          "clientSecretSettingName": "GITHUB_CLIENT_SECRET"
+        }
+      }
+    }
+  },
+  "routes": [
+    { "route": "/api/draft/*", "allowedRoles": ["authenticated"] },
+    { "route": "/.auth/login/aad", "statusCode": 404 },
+    { "route": "/.auth/login/twitter", "statusCode": 404 },
+    { "route": "/.auth/login/google", "statusCode": 404 }
+  ],
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/css/*", "/js/*", "/data/*", "/card-images/*", "/Icons/*", "/api/*"]
+    "exclude": ["/css/*", "/js/*", "/data/*", "/card-images/*", "/Icons/*", "/api/*", "/.auth/*"]
+  },
+  "responseOverrides": {
+    "401": { "statusCode": 401 }
   }
 }


### PR DESCRIPTION
## Summary

- Adds an authenticated `/api/draft` Azure Function backed by Azure Table Storage so drafts roam across devices and completed drafts are archived for later review.
- Wires GitHub OAuth via Static Web Apps' built-in auth (no custom auth code).
- Frontend debounces cloud saves at 1.5s, reconciles cloud vs. localStorage on mount via `lastModifiedAt`, archives on draft completion, and exposes a "Past Drafts" modal with a read-only `SummaryView`.
- Preserves the existing localStorage-only flow when signed out.

## Why

Cross-device continuity (start a draft on laptop, finish on phone) — `localStorage` was the bottleneck. Durable history of completed drafts also unblocks ad-hoc analysis (dump rows from Azure, paste into Claude).

## Files

**New**
- `api/draft/function.json`, `api/draft/index.js` — single function dispatching by `(method, action)`. Auth via `x-ms-client-principal`. Defensive 64KB state-blob cap.
- `js/draft-sync.js` — frontend client (`var`-namespace pattern, matches `strategy-advisor.js`).

**Modified**
- `staticwebapp.config.json` — GitHub provider, `/api/draft/*` requires `authenticated`, clean 401s, `/.auth/*` excluded from SPA fallback.
- `api/package.json` — adds `@azure/data-tables` (first npm dep).
- `draft.html` — `_lastModifiedAt` stamp on local saves; mount effect now async with cloud reconciliation + one-time migration push; debounced cloud save effect; archive-on-completion effect; `handleResetDraft` deletes cloud row; header auth indicator + "Past Drafts" button; `DraftHistoryModal` and `HistoryEntryViewer` components; `SummaryView` accepts `readOnly`.
- `css/draft.css` — `.auth-indicator`, `.history-modal`, `.history-entry*`, `.history-viewer-modal`.

## Storage schema

Single `drafts` table:
- `PartitionKey = u_<githubUserId>`
- `RowKey = active` (overwritten in-progress slot) or `RowKey = hist_<reverseTs>_<shortId>` (immutable archive)
- `state` is a JSON-stringified blob; `summaryMeta` on history rows is precomputed (player count, archetypes, occ/minor names) so the list modal doesn't deserialize state.

## Required Azure setup before this works in prod

1. **Storage Account** — create one (LRS is fine), copy connection string into SWA Configuration as `DRAFTS_STORAGE_CONNECTION_STRING`. Table is auto-created on first request.
2. **GitHub OAuth App** — register at github.com/settings/developers with callback `https://<swa-host>/.auth/login/github/callback`. Set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` in SWA Configuration.
3. Trigger a deploy (push to `main`) so the new function picks up the settings.

## Test plan

- [ ] Storage account created, connection string + GitHub client ID/secret added to SWA Configuration
- [ ] Sign in via GitHub from `/draft.html` — username + Sign out appear in header
- [ ] Pick cards through round 3, observe `PUT /api/draft/active` ~1.5s after each pick (debounced)
- [ ] Open a second browser, sign in with same account — current draft state appears
- [ ] Make a pick in browser B; refresh browser A → A picks up B's change
- [ ] Complete round 7 → `POST /api/draft/archive` then `DELETE /api/draft/active`; entry appears in "Past Drafts" modal
- [ ] Click history entry → read-only `SummaryView` renders archived draft
- [ ] Sign out → "Sign in" returns, draft state still loads from localStorage, no `/api/draft/*` calls fire
- [ ] One-time migration: with localStorage in-progress draft + empty cloud, sign in → immediate PUT pushes local up; refresh → no duplicate push
- [ ] Reset Draft (signed in) → both localStorage and cloud `active` row cleared
- [ ] Offline (DevTools): picks save to localStorage; cloud save fails silently; reconnect + next pick PUTs latest snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)